### PR TITLE
Extend node's vm space

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max-old-space-size=8192
 
 require('@oclif/command').run()
 .then(require('@oclif/command/flush'))

--- a/bin/run.cmd
+++ b/bin/run.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-node "%~dp0\run" %*
+node --max-old-space-size=8192 "%~dp0\run" %*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzdoc",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kuzdoc",
   "description": "The CLI that helps build the Kuzzle Docs",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "bin": {
     "kuzdoc": "./bin/run"


### PR DESCRIPTION
# Description

Asks node to run with more vm space, to prevent these errors we get when trying to deploy the development documentation:

https://github.com/kuzzleio/kuzzle/runs/1668704767